### PR TITLE
fix: mint a call id for tool calls so sessions with tool use resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Tool calls are emitted with a minted `CallId` instead of an empty one. Ollama's `/api/chat` wire format carries no tool-call id, so `OpenBlock.callId` was never assigned and both the `tool-call-delta` chunks and the closed block ended up as `CallId('')`. Live turns still paired the call with its result positionally, but the persisted `tool/result` carried an empty `source.callId` and the session failed validation on resume (`message must have tool source`).
+
 ## [0.1.1] - 2026-08-19
 
 ### Fixed

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -150,6 +150,12 @@ export async function* translate(lines: AsyncIterable<string>): AsyncGenerator<S
         let block = toolBlocks.get(callIndex)
         if (!block) {
           block = open('tool-call')
+          // Ollama's wire format carries no tool-call id, so mint one: without
+          // it the emitted chunks and the persisted tool result all carry an
+          // empty CallId, and the session fails validation on resume. Unique
+          // per block within the session; the index keeps same-millisecond
+          // parallel calls apart.
+          block.callId = `ollama-${Date.now().toString(36)}-${block.index}-${Math.random().toString(36).slice(2, 8)}`
           toolBlocks.set(callIndex, block)
           toolArguments.set(callIndex, '')
           yield { type: 'block-start', index: block.index, blockType: 'tool-call' }

--- a/test/translate.spec.ts
+++ b/test/translate.spec.ts
@@ -74,6 +74,41 @@ describe('translate', () => {
     expect(finish).toEqual({ type: 'finish', reason: { kind: 'tool-calls' } })
   })
 
+  it('mints a non-empty call id and reuses it for every chunk of the block', async () => {
+    const chunks = await collect([
+      '{"message":{"tool_calls":[{"function":{"name":"read","arguments":{"path":"/x"}}}]},"done":false}',
+      '{"message":{"tool_calls":[{"function":{"name":"read","arguments":{"path":"/x","line":1}}}]},"done":false}',
+      '{"message":{},"done":true,"done_reason":"tool_calls"}',
+    ])
+    const deltas = chunks.filter(chunk => chunk.type === 'tool-call-delta')
+    const ends = chunks.filter(chunk => chunk.type === 'block-end')
+    const ids = deltas.map(chunk => chunk.type === 'tool-call-delta' ? chunk.id : '')
+    const closed = ends[0]?.type === 'block-end' && ends[0].block.type === 'tool-call' ? ends[0].block.id : ''
+
+    // Ollama sends no id of its own: an empty one would reach the session log
+    // and break resume, so the block has to carry a minted one.
+    expect(ids.every(id => id.length > 0)).toBe(true)
+    expect(closed.length).toBeGreaterThan(0)
+    // Same block, same id: the call and its paired result must line up.
+    expect(new Set(ids).size).toBe(1)
+    expect(closed).toBe(ids[0])
+  })
+
+  it('gives parallel tool calls distinct ids', async () => {
+    const chunks = await collect([
+      '{"message":{"tool_calls":[{"function":{"name":"read","arguments":{"path":"/a"}}},{"function":{"name":"write","arguments":{"path":"/b"}}}]},"done":false}',
+      '{"message":{},"done":true,"done_reason":"tool_calls"}',
+    ])
+    const byIndex = new Map<number, string>()
+    for (const chunk of chunks) {
+      if (chunk.type === 'tool-call-delta') byIndex.set(chunk.index, chunk.id)
+    }
+    const ids = [...byIndex.values()]
+    expect(ids).toHaveLength(2)
+    expect(ids.every(id => id.length > 0)).toBe(true)
+    expect(new Set(ids).size).toBe(2)
+  })
+
   it('maps a stop finish with no content to an empty-response error', async () => {
     const chunks = await collect(['{"message":{},"done":true,"done_reason":"stop"}'])
     const finish = chunks[chunks.length - 1]


### PR DESCRIPTION
Fixes #1.

`OpenBlock.callId` is declared in `src/translate.ts` but never assigned, and Ollama's `/api/chat` wire format carries no tool-call id, so every `tool-call-delta` and every closed `tool-call` block is emitted as `CallId('')`. Live turns survive it — the harness pairs a call with its result positionally within the turn — but the persisted `tool/result` event carries an empty `source.callId`, and resuming that session fails validation with `session event at seq N message must have tool source`. In practice, any conversation that used a tool could not be continued.

## The fix

Mint an id when the tool-call block opens, unique per block within the session, in the shape you approved: a base-36 timestamp, the block index — which keeps same-millisecond parallel calls apart — and a short random suffix.

```ts
if (!block) {
  block = open('tool-call')
  block.callId = `ollama-${Date.now().toString(36)}-${block.index}-${Math.random().toString(36).slice(2, 8)}`
  toolBlocks.set(callIndex, block)
```

## Tests

Two regression tests in `test/translate.spec.ts`, in the existing `collect()` style:

- **`mints a non-empty call id and reuses it for every chunk of the block`** — a scripted tool-call stream yields a non-empty id on every `tool-call-delta`, the closed block carries the same id, and all of them match, so the call and its paired result line up.
- **`gives parallel tool calls distinct ids`** — two calls in one chunk get two different non-empty ids, one per `callIndex`.

Both fail without the fix (`expected false to be true`) and pass with it.

## Also

- `CHANGELOG.md` gains an `[Unreleased] / Fixed` entry.
- No config and no README changes: this restores intended behavior rather than adding a tunable.

## Verification

The full gate from `AGENTS.md`, all green on Node 24.19.0 / linux-arm64:

```
typecheck ✓   typecheck:ci ✓   test ✓ (79 tests, 13 files)   test:coverage ✓
build ✓   verify:self-contained ✓   verify:artifacts ✓
check-readme-sync ✓   pnpm pack ✓
```

Found while running dsh against a local `qwen3.8` (27B, tool-capable) on a DGX Spark / GB10 box: a session that had written a file could not be resumed. Patched locally through `pnpm patch` since then, and sessions have resumed cleanly.
