### PR TITLE
fix: open a new block when Ollama reuses a tool-call slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Tool calls are emitted with a minted `CallId` instead of an empty one. Ollama's `/api/chat` wire format carries no tool-call id, so `OpenBlock.callId` was never assigned and both the `tool-call-delta` chunks and the closed block ended up as `CallId('')`. Live turns still paired the call with its result positionally, but the persisted `tool/result` carried an empty `source.callId` and the session failed validation on resume (`message must have tool source`).
+- A tool-call array slot reused for a second, unrelated call now opens its own block instead of being diffed as a continuation. Ollama can reuse the same slot across chunks, and the longest-common-prefix diff previously emitted a fragment that reconstructed into invalid JSON while collapsing the two calls into one block.
 
 ## [0.1.1] - 2026-08-19
 

--- a/src/translate.ts
+++ b/src/translate.ts
@@ -70,6 +70,19 @@ function closeBlock(block: OpenBlock): ContentBlock {
 }
 
 /**
+ * Mint a session-unique tool-call id for a freshly opened block. Ollama's
+ * wire format carries no tool-call id, so one must be synthesized: without it
+ * the emitted chunks and the persisted tool result all carry an empty CallId,
+ * and the session fails validation on resume. The block index keeps
+ * same-millisecond parallel calls apart.
+ * @param block - the freshly opened tool-call block.
+ * @returns the minted id.
+ */
+function mintCallId(block: OpenBlock): string {
+  return `ollama-${Date.now().toString(36)}-${block.index}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+/**
  * Compute the append delta from a cumulative JSON string, so the harness's
  * delta-concatenating assembler reconstructs the full arguments. Ollama grows
  * the arguments object monotonically, so the delta is everything past the
@@ -83,6 +96,37 @@ export function argumentsDelta(previous: string, next: string): string {
   let index = 0
   while (index < previous.length && index < next.length && previous[index] === next[index]) index += 1
   return next.slice(index)
+}
+
+/**
+ * Whether the previous cumulative arguments object is a key/value subset of
+ * the next one, i.e. one call grew monotonically. While one call streams,
+ * Ollama only adds keys; when it reuses a slot for a new call, existing keys
+ * reappear with different values, so the subset check fails and the slot must
+ * open a fresh block. Non-object arguments (or either side failing to parse,
+ * which cannot happen for JSON.stringify output but keeps the guard total)
+ * fall back to treating the chunk as a continuation.
+ * @param previous - the previously seen cumulative JSON (or `''`).
+ * @param next - the new cumulative JSON.
+ * @returns `true` when `next` extends `previous` monotonically.
+ */
+export function isMonotonicExtension(previous: string, next: string): boolean {
+  if (previous === '') return true
+  let prevObj: unknown
+  let nextObj: unknown
+  try {
+    prevObj = JSON.parse(previous)
+    nextObj = JSON.parse(next)
+  } catch {
+    return true
+  }
+  if (typeof prevObj !== 'object' || prevObj === null || Array.isArray(prevObj)) return true
+  if (typeof nextObj !== 'object' || nextObj === null || Array.isArray(nextObj)) return true
+  for (const [key, value] of Object.entries(prevObj)) {
+    if (!(key in nextObj)) return false
+    if (JSON.stringify((nextObj as Record<string, unknown>)[key]) !== JSON.stringify(value)) return false
+  }
+  return true
 }
 
 /**
@@ -150,12 +194,7 @@ export async function* translate(lines: AsyncIterable<string>): AsyncGenerator<S
         let block = toolBlocks.get(callIndex)
         if (!block) {
           block = open('tool-call')
-          // Ollama's wire format carries no tool-call id, so mint one: without
-          // it the emitted chunks and the persisted tool result all carry an
-          // empty CallId, and the session fails validation on resume. Unique
-          // per block within the session; the index keeps same-millisecond
-          // parallel calls apart.
-          block.callId = `ollama-${Date.now().toString(36)}-${block.index}-${Math.random().toString(36).slice(2, 8)}`
+          block.callId = mintCallId(block)
           toolBlocks.set(callIndex, block)
           toolArguments.set(callIndex, '')
           yield { type: 'block-start', index: block.index, blockType: 'tool-call' }
@@ -166,7 +205,20 @@ export async function* translate(lines: AsyncIterable<string>): AsyncGenerator<S
         const cumulative = JSON.stringify(call?.function?.arguments ?? {})
         const previous = toolArguments.get(callIndex) ?? ''
         if (cumulative !== previous) {
-          const fragment = argumentsDelta(previous, cumulative)
+          if (!isMonotonicExtension(previous, cumulative)) {
+            // The cumulative arguments no longer extend the ones this slot has
+            // seen: Ollama reused the array slot for a second, unrelated call.
+            // Diffing against the old call would emit a fragment that
+            // reconstructs into invalid JSON and collapse the two calls into
+            // one block, so open a fresh block for the new call instead.
+            block = open('tool-call')
+            block.callId = mintCallId(block)
+            if (call?.function?.name !== undefined) block.name = call.function.name
+            toolBlocks.set(callIndex, block)
+            toolArguments.set(callIndex, '')
+            yield { type: 'block-start', index: block.index, blockType: 'tool-call' }
+          }
+          const fragment = argumentsDelta(toolArguments.get(callIndex) ?? '', cumulative)
           toolArguments.set(callIndex, cumulative)
           block.text += fragment
           yield {

--- a/test/translate.spec.ts
+++ b/test/translate.spec.ts
@@ -109,6 +109,25 @@ describe('translate', () => {
     expect(new Set(ids).size).toBe(2)
   })
 
+  it('opens a second block when Ollama reuses a slot for a new call', async () => {
+    const chunks = await collect([
+      '{"message":{"tool_calls":[{"function":{"name":"escribir_fichero","arguments":{"ruta":"/tmp/a.txt","contenido":"hola"}}}]},"done":false}',
+      '{"message":{"tool_calls":[{"function":{"name":"escribir_fichero","arguments":{"ruta":"/tmp/b.txt","contenido":"adios"}}}]},"done":false}',
+      '{"message":{},"done":true,"done_reason":"tool_calls"}',
+    ])
+    const starts = chunks.filter(chunk => chunk.type === 'block-start')
+    const ends = chunks.filter(chunk => chunk.type === 'block-end')
+    expect(starts).toHaveLength(2)
+    expect(ends).toHaveLength(2)
+    const args = ends.map(chunk => chunk.type === 'block-end' && chunk.block.type === 'tool-call' ? chunk.block.arguments : '')
+    // Both calls survive as complete, separately parseable JSON instead of
+    // collapsing into one fragmented block with invalid arguments.
+    expect(JSON.parse(args[0]!)).toEqual({ ruta: '/tmp/a.txt', contenido: 'hola' })
+    expect(JSON.parse(args[1]!)).toEqual({ ruta: '/tmp/b.txt', contenido: 'adios' })
+    const ids = ends.map(chunk => chunk.type === 'block-end' && chunk.block.type === 'tool-call' ? chunk.block.id : '')
+    expect(ids[0]).not.toBe(ids[1])
+  })
+
   it('maps a stop finish with no content to an empty-response error', async () => {
     const chunks = await collect(['{"message":{},"done":true,"done_reason":"stop"}'])
     const finish = chunks[chunks.length - 1]


### PR DESCRIPTION
Fixes #3.

Ollama can reuse the same `tool_calls[]` array slot for a second, unrelated call across chunks (observed with a tool-capable local model chaining two uses of the same tool). The longest-common-prefix diff then treated the second call as a continuation: the emitted fragment reconstructed into invalid JSON and both calls collapsed into a single block, surfacing as `SyntaxError: Unexpected non-whitespace character after JSON` and retry loops.

## The fix

`src/translate.ts` gains `isMonotonicExtension(previous, next)`: while one call streams, the cumulative arguments object only adds keys, so the previous object is a key/value subset of the next one. When the subset check fails — existing keys reappearing with different values — the slot was reused for a new call, and a fresh block with a freshly minted call id is opened instead of diffing against the old call.

- Monotonic extension: previous keys keep their values, new keys may appear → continuation, LCP diff unchanged.
- Reused slot: any previous key changes value (e.g. `ruta` changes between two `escribir_fichero` calls) → new block, full arguments as the first delta.

## Tests

One regression test in `test/translate.spec.ts` replays the exact probe from #3 (two `escribir_fichero` calls in one slot):

- `opens a second block when Ollama reuses a slot for a new call` — two `block-start`/`block-end` pairs, each block's arguments parse as complete valid JSON with the right values, and the two blocks carry distinct ids.

It fails without the fix (one block, broken JSON) and passes with it.

## Gates (all green, run locally)

`typecheck` / `typecheck:ci` / `test` (80 tests, 13 files) / `test:coverage` (translate.ts 98.75%, thresholds 90/80/90/90) / `build` / `verify:self-contained` / `verify:artifacts` / `check-readme-sync`