### PR TITLE
docs: add official-repository declaration to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 *Discover, pull, remove, and inspect local models, route requests to them by task type or keyword with automatic fallback to the cloud, and get a one-shot status overview via `/ollama`.*
 
+> **Official repository.** This is the only official repository of dsh-local-ai, maintained by PerryLink. Same-name repositories under other accounts are not affiliated.
+
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![DSH plugin](https://img.shields.io/badge/dsh-plugin-✅-green)](https://github.com/topics/dsh-plugin)
 [![Node](https://img.shields.io/badge/node-%5E22.19%20%7C%7C%20%3E%3D24-brightgreen.svg)](#)

--- a/README.zh.md
+++ b/README.zh.md
@@ -7,6 +7,8 @@
 
 *发现、拉取、删除、查看本地模型，按任务类型或关键词把请求分流到本地模型并在失败时自动回退云端，通过 `/ollama` 一键查看状态总览。*
 
+> **官方仓库。** 本仓库是 dsh-local-ai 的唯一官方仓库，由 PerryLink 维护。其他账号下的同名仓库与本项目无关。
+
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 [![DSH plugin](https://img.shields.io/badge/dsh-plugin-✅-green)](https://github.com/topics/dsh-plugin)
 [![Node](https://img.shields.io/badge/node-%5E22.19%20%7C%7C%20%3E%3D24-brightgreen.svg)](#)


### PR DESCRIPTION
Adds the official-repository declaration (en/zh) for brand protection against same-name repositories. Same-name repos under other accounts are not affiliated.